### PR TITLE
fixed regex for backslash replacement to replace all backslashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,8 +62,7 @@ module.exports = function router (routesDir, config) {
 
         route.path = '/' + path.relative(routesDir, routeFile).replace(extPattern, '')
         //Fix issue with windows paths
-        route.path = route.path.replace(/\\/, '/')
-
+        route.path = route.path.replace(/\\/g, '/')
       }
       return route
     })


### PR DESCRIPTION
On windows I just had the error that a path looking like this:

`someFolder\%someParam\index`

got transformed to this

`someFolder/%someParam\index`

so only the first backslash got replaced by a normal slash.

The fix is to add a `g` flag to the replacement regex so that all backslashes match