### PR TITLE
Fixed exports in type declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,9 @@
+import { IncomingMessage } from 'http'
+import { RequestHandler } from 'micro'
+
+export interface fConfig {
+    filter: (f: string) => boolean
+}
+
+export function match(req: IncomingMessage): RequestHandler | void
+export function router(routesDir: string, config?: fConfig): (req: IncomingMessage) => RequestHandler | void

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,11 @@
 import { IncomingMessage } from 'http'
 import { RequestHandler } from 'micro'
 
-export interface fConfig {
+interface fConfig {
     filter: (f: string) => boolean
 }
 
-export function match(req: IncomingMessage): RequestHandler | void
-export function router(routesDir: string, config?: fConfig): (req: IncomingMessage) => RequestHandler | void
+declare function match(req: IncomingMessage): RequestHandler | void
+declare function router(routesDir: string, config?: fConfig): (req: IncomingMessage) => RequestHandler | void
+
+export = router

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/jesseditson/fs-router#readme",
   "devDependencies": {
+    "@types/micro": "^7.3.1",
     "coveralls": "^2.11.15",
     "nyc": "^10.0.0",
     "tape": "^4.6.3"


### PR DESCRIPTION
I ran into issue when I tried to use the new type declarations. Example code:

```typescript
import { router } from 'fs-router'
let intents = router(__dirname + '/intents')
```

Typescript was able to compile this, but running the code caused this error: 

> TypeError: fs_router_1.router is not a function

I realized this was because the library uses this syntax: 

```javascript
module.exports = function router() {
```

Instead of this syntax: 

```javascript
module.exports.router = function router() {
```

I made these changes to support that fact. 

Incidentally, with this change, my code no longer compiled. Typescript returned an error like

> Module '${my app path}/node_modules/fs-router/index"' resolves to a non-module entity and cannot be imported using this construct.

I modified my usage to this:

```typescript
import Router = require('fs-router')
let intents = Router(__dirname + '/intents')
```

And now everything seems happy. 