### PR TITLE
Use multiple file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,21 @@ the above tree would generate the following routes:
 /foo/thing
 /bar/foo
 ```
+
+**Multiple file extensions**
+```javascript
+// index.js
+const { send } = require('micro')
+
+// set up the config to both include .js and .ts files.
+const config = {ext: ['.js', '.ts']}
+
+// pass config to `fs-router` as optional second paramater
+let match = require('fs-router')(__dirname + '/routes', config)
+
+module.exports = async function(req, res) {
+  let matched = match(req)
+  if (matched) return await matched(req, res)
+  send(res, 404, { error: 'Not found' })
+}
+```

--- a/index.js
+++ b/index.js
@@ -38,19 +38,20 @@ function addMatch (route) {
 }
 
 // recursively searches for all js files inside a directory tree, and returns their full paths
-function findRoutes (dir) {
+function findRoutes (dir, fileExtensions) {
+//  fileExtensions = (fileExtensions instanceof Array) ? fileExtensions : ['.js']
   let files = fs.readdirSync(dir)
   let resolve = f => path.join(dir, f)
-  let routes = files.filter(f => path.extname(f) === '.js').map(resolve)
+  let routes = files.filter(f => fileExtensions.indexOf(path.extname(f)) !== -1).map(resolve)
   let dirs = files.filter(f => fs.statSync(path.join(dir, f)).isDirectory()).map(resolve)
-  return routes.concat(...dirs.map(findRoutes))
+  return routes.concat(...dirs.map(subdir => findRoutes(subdir, fileExtensions)))
 }
 
 const val = v => (typeof v === 'undefined' ? 0 : v)
 
 module.exports = function router (routesDir, config) {
-
-  const routes = findRoutes(routesDir)
+  const fileExtensions = config && config.ext && config.ext instanceof Array ? config.ext : ['.js']
+  const routes = findRoutes(routesDir, fileExtensions)
     // if filter function is set, filter routes
     .filter(config && config.filter || function () { return true })
     // require route files, then add a 'path' property to them

--- a/test/extensions-test.js
+++ b/test/extensions-test.js
@@ -1,0 +1,22 @@
+const path = require('path')
+const test = require('tape')
+const router = require('..')
+
+// use both ts and js scripts
+const config = {ext: ['.js', '.ts']}
+
+let match = router(path.join(__dirname, '/fixtures/extensions'), config)
+
+test('includes the index.js', t => {
+  t.plan(2)
+  let req = { url: '/', method: 'GET' }
+  t.equal(typeof match(req), 'function', 'returns the route function')
+  t.equal(match(req)(), 'index', 'route function is callable')
+})
+
+test('includes the typescript file', t => {
+  t.plan(2)
+  let req = { url: '/typescript', method: 'GET' }
+  t.equal(typeof match(req), 'function', 'returns the route function')
+  t.equal(match(req)(), 'typescript', 'route function is callable')
+})

--- a/test/fixtures/extensions/index.js
+++ b/test/fixtures/extensions/index.js
@@ -1,0 +1,1 @@
+module.exports = () => 'index'

--- a/test/fixtures/extensions/typescript.ts
+++ b/test/fixtures/extensions/typescript.ts
@@ -1,0 +1,1 @@
+module.exports = () => 'typescript'


### PR DESCRIPTION
I am converting my project that uses fs-router for development to a typescript project. After I converted the relevant bits and added ts-node to my project, I noticed that fs-router only looks for `.js`files. So I wrote some lines of code to also allow multiple extensions.

_Usage_
```javascript
const config = { ext: ['.js', '.ts'] };
// Use this config object for files with .js and .ts extension
```

If you have any commends on this PR, please let me know. I would like to see it released ;). 