### PR TITLE
Support ESModules

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ function addMatch (route) {
 
 // recursively searches for all js files inside a directory tree, and returns their full paths
 function findRoutes (dir, fileExtensions) {
-//  fileExtensions = (fileExtensions instanceof Array) ? fileExtensions : ['.js']
   let files = fs.readdirSync(dir)
   let resolve = f => path.join(dir, f)
   let routes = files.filter(f => fileExtensions.indexOf(path.extname(f)) !== -1).map(resolve)
@@ -79,7 +78,7 @@ module.exports = function router (routesDir, config) {
 
   // generated match method - call with a req object to get a route.
   return function match (req) {
-    let routeFn = r => r[req.method] || (typeof r === 'function' && r)
+    let routeFn = r => r[req.method] || (typeof r === 'function' && r) || (typeof r.default === 'function' && r.default)
     let found = routes.find(r => {
       let matched = r.match(req.url)
       let hasFn = routeFn(r)


### PR DESCRIPTION
During my adventure with a typescript project I noticed that the router found and parsed my (.ts) files, but that they did not match. After some debugging I found out the ESM exports the default function to the `default` key. With this little adaption, it works again. 

I also removed a comment I left in the code with my last PR :see_no_evil: 