### PR TITLE
Wrap typescript defenition within module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,15 @@
 import { IncomingMessage } from 'http'
 import { RequestHandler } from 'micro'
 
-interface fConfig {
-    filter: (f: string) => boolean
+declare module 'fs-router' {
+    // eslint-disable-next-line  @typescript-eslint/class-name-casing
+    interface fConfig {
+        filter?: (f: string) => boolean;
+        ext?: string[];
+    }
+
+    export function match(req: IncomingMessage): RequestHandler | void
+
+    export default function router(routesDir: string, config?: fConfig): (req: IncomingMessage) => RequestHandler | void
 }
 
-declare function match(req: IncomingMessage): RequestHandler | void
-declare function router(routesDir: string, config?: fConfig): (req: IncomingMessage) => RequestHandler | void
-
-export = router


### PR DESCRIPTION
My typescript setup did not recognize the `fs-router` module, because it where only functions. Now it is wrapped in a module and should be recognized by the parser. 