### PR TITLE
Fixed windows tests and added multiple OS to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
+os:
+  - linux
+  - osx
+  - windows
 language: node_js
-script: nyc npm test
-after_success: npm run coveralls
 node_js:
   - "6"
   - "node"
+script: nyc npm test
+after_success: npm run coveralls

--- a/test/custom-filter-test.js
+++ b/test/custom-filter-test.js
@@ -3,7 +3,7 @@ const test = require('tape')
 const router = require('..')
 
 // set up config to filter only paths ending `index.js`
-const config = {filter: f => /(?:^|\/)index.js$/.test(f)}
+const config = { filter: f => /(?:^|[\/,\\])index.js$/.test(f) }
 
 let match = router(path.join(__dirname, '/fixtures/filter'), config)
 


### PR DESCRIPTION
- Updated the test filter regex to include also windows paths
- Added multiple os configuration to travis config, see #6

I've cloned and tested on my windows machine (that's why I discovered the regex issue) and it worked, so I assume it should work also on travis windows image, let see..